### PR TITLE
Script running fixes

### DIFF
--- a/py/IGDetective.py
+++ b/py/IGDetective.py
@@ -15,6 +15,8 @@ from multiprocessing import get_context
 
 import extract_aligned_genes as align_utils
 
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 #INITIALIZE VARIABLES, default = IGH
 V = 'V'
 D = 'D'
@@ -52,7 +54,8 @@ def InitializeVariables(locus):
 
 #READ DATAFILES
 try:
-    with open('datafiles/motifs', 'rb') as f:   
+    motifs_file = os.path.join(SCRIPT_DIR[:-3], 'datafiles', 'motifs')
+    with open(motifs_file, 'rb') as f:   
         VALID_MOTIFS = pickle.load(f)
 except:
     print("Error: could not find the input data files. Please make sure the IGDetective.py file and datafiles folder are in the same directory")
@@ -130,7 +133,7 @@ input_seq_dict= {rec.id : rec.seq for rec in SeqIO.parse(INPUT_PATH, "fasta")}
 
 canonical_genes = {V : {} , J : {}}
 for gene in (V,J):
-    file_path = 'datafiles/combined_reference_genes/' + LOCUS + gene + '.fa' #'datafiles/human_{}.fasta'.format(gene)
+    file_path = os.path.join(SCRIPT_DIR[:-3], 'datafiles', 'combined_reference_genes', LOCUS + gene + '.fa') #'datafiles/human_{}.fasta'.format(gene)
     canonical_genes[gene] = {rec.id : rec.seq.upper() for rec in SeqIO.parse(file_path, "fasta")}
 
 #DEFINE RSS FINDING METHODS

--- a/py/analyze_matches.py
+++ b/py/analyze_matches.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import gzip
 import shutil
 import re
 import numpy as np
@@ -148,7 +149,7 @@ def OutputLoci(contig_id, contig_seq, loci_bounds, output_dir):
 ######################################################
 input_dir = sys.argv[1]
 output_dir = sys.argv[2]
-contig_fasta = sys.argv[3]
+contig_file = sys.argv[3]
 
 if os.path.exists(output_dir):
     shutil.rmtree(output_dir)
@@ -181,10 +182,15 @@ for locus, gene in gene_sam_dict:
         combined_matches[contig][(locus, gene)] = compressed_matches
 
 contig_seqs = dict() # contig ID -> seq
-for r in SeqIO.parse(contig_fasta, 'fasta'):
+if contig_file.endswith('.gz'):
+    contig_handle = gzip.open(contig_file, 'rt')
+else:
+    contig_handle = open(contig_file, 'r')
+for r in SeqIO.parse(contig_handle, 'fasta'):
     if r.id not in combined_matches:
         continue
     contig_seqs[r.id] = str(r.seq)
+contig_handle.close()
 
 matrix = []
 annot_matrix = []

--- a/py/extract_aligned_genes.py
+++ b/py/extract_aligned_genes.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import gzip
 import shutil
 import pandas as pd
 from Bio import SeqIO
@@ -139,11 +140,16 @@ def main(genome_fasta, gene_fasta, output_dir):
     if len(position_dict) == 0:
         print('no matches were found')
         return
-
+    
+    if genome_fasta.endswith('.gz'):
+        genome_handle = gzip.open(genome_fasta, 'rt')
+    else:
+        genome_handle = open(genome_fasta, 'r')
     contig_dict = dict()
-    for r in SeqIO.parse(genome_fasta, 'fasta'):
+    for r in SeqIO.parse(genome_handle, 'fasta'):
         if r.id in position_dict:
             contig_dict[r.id] = str(r.seq)
+    genome_handle.close()
 
     genes = []
     for r in SeqIO.parse(gene_fasta, 'fasta'):

--- a/py/locus_boundaries_refiner.py
+++ b/py/locus_boundaries_refiner.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import gzip
 import pandas as pd
 import numpy as np
 from Bio import SeqIO
@@ -152,12 +153,17 @@ def main(genome_fasta, input_dir, output_dir):
     contig_set = set(df['Contig'])
     contig_len_dict = dict()
     contig_seq_dict = dict()
-    for r in SeqIO.parse(genome_fasta, 'fasta'):
+    if genome_fasta.endswith('.gz'):
+        genome_fasta_handle = gzip.open(genome_fasta, 'rt')
+    else:
+        genome_fasta_handle = open(genome_fasta, 'r')
+    for r in SeqIO.parse(genome_fasta_handle, 'fasta'):
         contig_id = r.id.replace('|', '_')
         if contig_id not in contig_set:
             continue
         contig_len_dict[contig_id] = len(r.seq)
         contig_seq_dict[contig_id] = str(r.seq)
+    genome_fasta_handle.close()
 
     #### creating summary dataframe
     shift = 10000

--- a/run_iterative_igdetective.py
+++ b/run_iterative_igdetective.py
@@ -13,12 +13,13 @@ mplt.use('Agg')
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-sys.path.append('py')
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(SCRIPT_DIR, 'py'))
 import extract_aligned_genes as gene_finding_tools
 import visualization_tools as visual_tools
 import locus_boundaries_refiner as locus_refiner
 
-ref_gene_dir = 'datafiles/human_reference_genes'
+ref_gene_dir = os.path.join(SCRIPT_DIR, 'datafiles', 'human_reference_genes')
 
 def CheckPythonVersionFatal():
     if sys.version_info.major != 3:
@@ -63,7 +64,8 @@ def AlignReferenceGenes(align_dir, genome_fasta, ig_gene_dir, output_dir):
 
 def IdentifyIGContigs(igcontig_dir, alignment_dir, output_dir, genome_fasta):
     match_log = igcontig_dir + '.out'
-    os.system('python py/analyze_matches.py ' + alignment_dir + ' ' + igcontig_dir + ' ' + genome_fasta + ' > ' + match_log)
+    AM_SCRIPT_PATH = os.path.join(SCRIPT_DIR, 'py', 'analyze_matches.py')
+    os.system('python ' + AM_SCRIPT_PATH + ' ' + alignment_dir + ' ' + igcontig_dir + ' ' + genome_fasta + ' > ' + match_log)
 
 def GetPositionRange(sorted_positions):
     if len(sorted_positions) == 1:
@@ -123,7 +125,8 @@ def RunIgDetective(igcontig_dir, output_dir, locus = 'IGH'):
     fh.close()
     # running IgDetective
     igdetective_dir = os.path.join(output_dir, 'predicted_genes_' + locus)
-    command_line = 'python py/IGDetective.py -i ' + fasta + ' -o ' + igdetective_dir + ' -m 1 -l ' + locus
+    IGD_PATH = os.path.join(SCRIPT_DIR, 'py', 'IGDetective.py')
+    command_line = 'python ' + IGD_PATH + ' -i ' + fasta + ' -o ' + igdetective_dir + ' -m 1 -l ' + locus
     print('Running: ' + command_line)
     os.system(command_line + ' > ' + os.path.join(output_dir, 'predicted_genes_' + locus + '.out'))
 
@@ -314,5 +317,5 @@ if __name__ == '__main__':
         sys.exit(1)
     genome_fasta = sys.argv[1]
     output_dir = sys.argv[2]
-    ig_gene_dir = 'datafiles/combined_reference_genes' #sys.argv[3]
+    ig_gene_dir = os.path.join(SCRIPT_DIR, "datafiles", "combined_reference_genes") #sys.argv[3]
     main(genome_fasta, output_dir, ig_gene_dir)


### PR DESCRIPTION
Dear Yana,

1. Scripts from "py" directory and files from "datafiles" are called in relation to main script run folder. It throws file errors if run_iterative_igdetective.py was run from other place that is not its directory. Fixed with adding relative paths with main script location.

2. IgDetective did not parse gzipped genomes. I added gzip file handles for SeqIO if genome filename ends with .gz